### PR TITLE
Fix quickfix close mapping description

### DIFF
--- a/lua/custom/keymapping.lua
+++ b/lua/custom/keymapping.lua
@@ -128,4 +128,4 @@ map("n", "<leader>lg", "<cmd>lua _lazygit_toggle()<CR>", { desc = 'toggle lazygi
 
 -- quickfix
 map('n', '<leader>co', ':copen<CR>', { desc = 'open quickfix window' })
-map('n', '<leader>cc', ':cclose<CR>', { desc = 'close quico/fix window' })
+map('n', '<leader>cc', ':cclose<CR>', { desc = 'close quickfix window' })


### PR DESCRIPTION
## Summary
- correct the description for closing the quickfix window in custom keymaps

## Testing
- `npx --yes stylua lua/custom/keymapping.lua` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab75a9508321a60d45e0a8737529