### PR TITLE
Fix local toggle function for lazygit

### DIFF
--- a/lua/custom/keymapping.lua
+++ b/lua/custom/keymapping.lua
@@ -117,14 +117,14 @@ map('n', '<leader>tf', ':lua require("neotest").run.run(vim.fn.expand("%"))<CR>'
 map('n', '<leader>z', ':ToggleTerm name=default<CR>', { desc = 'toggle default terminal' })
 map('t', 'zz', [[<C-\><C-n>]], { desc = 'to normal mode' })
 
-local Terminal  = require('toggleterm.terminal').Terminal
-local lazygit = Terminal:new({ cmd = "lazygit", hidden = true })
+local Terminal = require('toggleterm.terminal').Terminal
+local lazygit = Terminal:new({ cmd = 'lazygit', hidden = true })
 
-function _lazygit_toggle()
+local function lazygit_toggle()
   lazygit:toggle()
 end
 
-map("n", "<leader>lg", "<cmd>lua _lazygit_toggle()<CR>", { desc = 'toggle lazygit' })
+map('n', '<leader>lg', lazygit_toggle, { desc = 'toggle lazygit' })
 
 -- quickfix
 map('n', '<leader>co', ':copen<CR>', { desc = 'open quickfix window' })


### PR DESCRIPTION
## Summary
- scope the `lazygit_toggle` helper locally
- update `<leader>lg` keymap to use the local function

## Testing
- `stylua lua/custom/keymapping.lua` *(fails: command not found)*
- `npx stylua lua/custom/keymapping.lua` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab7862408321802b8a1999b32058