### PR TITLE
Implement LSP check for Neo-tree symbols

### DIFF
--- a/lua/custom/keymapping.lua
+++ b/lua/custom/keymapping.lua
@@ -173,15 +173,32 @@ map('n', '<leader>lg', lazygit_toggle, { desc = 'toggle lazygit' })
 map('n', '<leader>co', ':copen<CR>', { desc = 'open quickfix window' })
 map('n', '<leader>cc', ':cclose<CR>', { desc = 'close quickfix window' })
 
--- Open Neo-tree with filesystem and document symbols in a split
 local function neotree_files_and_symbols()
   -- Open the filesystem view on the left and focus it
   vim.cmd('Neotree filesystem reveal left')
-  -- Split the Neo-tree window and open document symbols below
-  vim.cmd('wincmd s')
-  vim.cmd('Neotree document_symbols reveal current')
-  -- Return focus to the previous window
-  vim.cmd('wincmd p')
+
+  local function open_symbols()
+    vim.cmd('wincmd s')
+    vim.cmd('Neotree document_symbols reveal current')
+    vim.cmd('wincmd p')
+  end
+
+  local function has_lsp()
+    local clients = vim.lsp.buf_get_clients(0)
+    return clients and next(clients)
+  end
+
+  if has_lsp() then
+    open_symbols()
+  else
+    vim.defer_fn(function()
+      if has_lsp() then
+        open_symbols()
+      else
+        vim.notify('No active LSP attached. Document symbols unavailable', vim.log.levels.WARN)
+      end
+    end, 100)
+  end
 end
 
 map('n', '<leader>ns', neotree_files_and_symbols, { desc = 'neo-tree: files + symbols' })


### PR DESCRIPTION
## Summary
- update `neotree_files_and_symbols` to check if an LSP is active
- delay opening document symbols until an LSP attaches or warn if none

## Testing
- `stylua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4d1421808321b9ed2cc8e713a02c