### PR TITLE
Add kitty neo-tree window

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,4 +18,9 @@ vim.api.nvim_create_autocmd('FileType', {
   end,
 })
 
+-- Start Neovim in server mode if not already started
+if vim.v.servername == '' then
+  vim.fn.serverstart('/tmp/nvim-main.sock')
+end
+
 require 'my_kickstart'

--- a/lua/custom/keymapping.lua
+++ b/lua/custom/keymapping.lua
@@ -1,4 +1,5 @@
 local map = vim.keymap.set
+local kitty_neotree = require('custom.kitty_neotree')
 
 -------------------------------------------------------------------------------
 -- Pytest integration
@@ -173,23 +174,7 @@ map('n', '<leader>lg', lazygit_toggle, { desc = 'toggle lazygit' })
 map('n', '<leader>co', ':copen<CR>', { desc = 'open quickfix window' })
 map('n', '<leader>cc', ':cclose<CR>', { desc = 'close quickfix window' })
 
-local function neotree_files_and_symbols()
-  -- Open the filesystem view on the left and focus it
-  vim.cmd('Neotree filesystem reveal left')
-
-  local function open_symbols()
-    vim.cmd('wincmd s')
-    vim.cmd('sleep 10m')
-    vim.cmd('Neotree document_symbols reveal current')
-    vim.cmd('wincmd p')
-  end
-
-  vim.defer_fn(function()
-    open_symbols()
-  end, 100)
-end
-
-map('n', '<leader>ns', neotree_files_and_symbols, { desc = 'neo-tree: files + symbols' })
+map('n', '<leader>ns', kitty_neotree.launch, { desc = 'neo-tree: files + symbols' })
 
 -- copy the current buffer's file path to the clipboard
 map('n', '<leader>yf', function()

--- a/lua/custom/kitty_neotree.lua
+++ b/lua/custom/kitty_neotree.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+-- Launch a kitty window running the current Neovim instance
+function M.launch()
+  -- Ensure server is running
+  if vim.v.servername == '' then
+    vim.fn.serverstart('/tmp/nvim-main.sock')
+  end
+
+  -- Command to run in the new kitty window
+  local cmd = {
+    'kitty', '@', 'launch', '--type=window',
+    'nvim', '--server', '/tmp/nvim-main.sock', '--remote-ui',
+    '+lua require("custom.kitty_neotree").setup()'
+  }
+  vim.fn.jobstart(cmd, { detach = true })
+end
+
+-- Prepare the neo-tree views in this UI
+function M.setup()
+  vim.cmd('tabnew')
+  vim.cmd('Neotree filesystem reveal left')
+  vim.cmd('wincmd o')
+  vim.cmd('Neotree document_symbols reveal right')
+end
+
+return M


### PR DESCRIPTION
## Summary
- start nvim server automatically
- create `kitty_neotree` module to open neo-tree in a dedicated kitty window
- map `<leader>ns` to launch this kitty window

## Testing
- `nvim` not installed, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_686f5fdb6dd08321b2abc6f2bc739260