### PR TITLE
Add Neo-tree Kitty launcher

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -24,3 +24,8 @@ if vim.v.servername == '' then
 end
 
 require 'my_kickstart'
+
+-- Launch a dedicated Neo-tree window in Kitty
+vim.keymap.set('n', '<leader>ns', function()
+  require('custom.kitty_neotree_launcher').launch()
+end, { desc = 'neo-tree: files + symbols' })

--- a/lua/custom/kitty_neotree_launcher.lua
+++ b/lua/custom/kitty_neotree_launcher.lua
@@ -1,6 +1,6 @@
 local M = {}
 
--- Launch a kitty window connected to the current Neovim instance
+---Launch a kitty window showing only Neo-tree views
 function M.launch()
   local server = vim.v.servername
 
@@ -10,10 +10,11 @@ function M.launch()
     vim.fn.serverstart(server)
   end
 
+  local config = vim.fn.stdpath('config') .. '/neotree_only.lua'
+
   local cmd = {
-    'kitty', '@', 'launch', '--type=window',
-    'nvim', '--server', server, '--remote-ui',
-    '+lua require("custom.kitty_neotree_setup").setup()'
+    'kitty', '@', 'launch', '--type=window', '--title', 'Neo-tree',
+    'nvim', '--server', server, '--remote-ui', '-u', config,
   }
   vim.fn.jobstart(cmd, { detach = true })
 end

--- a/neotree_only.lua
+++ b/neotree_only.lua
@@ -1,0 +1,7 @@
+vim.o.loadplugins = false
+
+vim.defer_fn(function()
+  vim.cmd('Neotree filesystem reveal left')
+  vim.cmd('wincmd o')
+  vim.cmd('Neotree document_symbols reveal right')
+end, 100)


### PR DESCRIPTION
## Summary
- add `kitty_neotree_launcher.lua` that starts a Neo-tree only Kitty window
- create minimal `neotree_only.lua` to configure the remote UI
- bind `<leader>ns` in `init.lua` to launch the Kitty window

## Testing
- `stylua .` *(fails: stylua not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f8aad4b088321a7d6d29e832e3bb5