### PR TITLE
Add sidebar layout with Neo-tree and Aerial

### DIFF
--- a/lua/custom/keymapping.lua
+++ b/lua/custom/keymapping.lua
@@ -182,3 +182,7 @@ map('n', '<leader>yf', function()
   vim.fn.setreg('+', path)
   vim.notify('Copied path: ' .. path)
 end, { desc = '[Y]ank current [F]ile path' })
+
+-- open Neo-tree and Aerial layout
+local sidebar = require('custom.sidebar')
+map('n', '<leader>e', sidebar.open, { desc = 'explorer && symbols' })

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -18,4 +18,11 @@ return {
       "knubie/vim-kitty-navigator",
       build = "cp ./*.py ~/.config/kitty/",
   },
+  {
+    'stevearc/aerial.nvim',
+    opts = {},
+    config = function(_, opts)
+      require('aerial').setup(opts)
+    end,
+  },
 }

--- a/lua/custom/sidebar.lua
+++ b/lua/custom/sidebar.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+function M.open()
+  -- Open Neo-tree on the left
+  vim.cmd('Neotree filesystem reveal left')
+  local neo_win = vim.api.nvim_get_current_win()
+
+  -- Split the Neo-tree window horizontally for Aerial
+  vim.cmd('split')
+  local aerial_win = vim.api.nvim_get_current_win()
+
+  -- Open Aerial in the bottom split
+  require('aerial').open({ direction = 'left', focus = false })
+
+  -- Resize the splits: more space for Neo-tree (60%)
+  local total = vim.api.nvim_win_get_height(neo_win) + vim.api.nvim_win_get_height(aerial_win)
+  local neo_h = math.floor(total * 0.6)
+  vim.api.nvim_win_set_height(neo_win, neo_h)
+  vim.api.nvim_win_set_height(aerial_win, total - neo_h)
+
+  -- Move focus back to the main editor window
+  vim.cmd('wincmd l')
+end
+
+return M
+

--- a/lua/my_kickstart.lua
+++ b/lua/my_kickstart.lua
@@ -223,5 +223,12 @@ require 'my_kickstart_lazy'
 
 require 'custom.keymapping'
 
+-- Open Neo-tree and Aerial on startup
+vim.api.nvim_create_autocmd('VimEnter', {
+  callback = function()
+    require('custom.sidebar').open()
+  end,
+})
+
 -- The line beneath this is called `modeline`. See `:help modeline`
 -- vim: ts=2 sts=2 sw=2 et


### PR DESCRIPTION
## Summary
- install `aerial.nvim`
- implement `custom.sidebar.open` helper
- map `<leader>e` to open Neo-tree with Aerial below it
- open sidebar layout automatically on startup

## Testing
- `nvim` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f97a43e6c8321a17e4141ebee85d4