### PR TITLE
feat: add window management hotkeys

### DIFF
--- a/lua/custom/keymapping.lua
+++ b/lua/custom/keymapping.lua
@@ -1,5 +1,10 @@
 local map = vim.keymap.set
 
+-- Window management
+map('n', '<leader>wn', ':new<CR>', { desc = '[W]indow [N]ew' })
+map('n', '<leader>wc', ':close<CR>', { desc = '[W]indow [C]lose' })
+map('n', '<leader>wt', ':tabnew<CR>', { desc = '[W]indow [T]ab' })
+
 -------------------------------------------------------------------------------
 -- Pytest integration
 -------------------------------------------------------------------------------

--- a/lua/my_kickstart_lazy.lua
+++ b/lua/my_kickstart_lazy.lua
@@ -112,7 +112,7 @@ require('lazy').setup({
         { '<leader>d', group = '[D]ocument' },
         { '<leader>r', group = '[R]ename' },
         { '<leader>s', group = '[S]earch' },
-        { '<leader>w', group = '[W]orkspace' },
+        { '<leader>w', group = '[W]indow' },
         { '<leader>t', group = '[T]oggle' },
         { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
       },


### PR DESCRIPTION
## Summary
- add <leader>wn, <leader>wc, and <leader>wt to quickly open windows, close the current window, and create a new tab
- update which-key group name to reflect window actions

## Testing
- `stylua lua/custom/keymapping.lua lua/my_kickstart_lazy.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*
- `nvim --headless -u NONE -c "luafile lua/custom/keymapping.lua" -c "q"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d9c2c848321ae1aeaa0ab88006b